### PR TITLE
fix: use searchable select widget for pp merge page

### DIFF
--- a/participants/forms.py
+++ b/participants/forms.py
@@ -2,8 +2,9 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.text import gettext_lazy as _
 
-from cdh.core.forms import (TelephoneInput,BootstrapRadioSelect,
-                            BootstrapCheckboxInput)
+from cdh.core.forms import (SearchableSelectWidget, TelephoneInput,
+                            BootstrapRadioSelect,
+                            BootstrapCheckboxInput, )
 from main.forms import PPNTemplatedForm, PPNTemplatedModelForm
 
 from .models import CriterionAnswer, Participant
@@ -61,11 +62,13 @@ class ParticipantMergeForm(PPNTemplatedForm):
     old_participant = forms.ModelChoiceField(
         Participant.objects.all(),
         label=_('participants:merge_form:field:old_participant'),
+        widget=SearchableSelectWidget,
     )
 
     new_participant = forms.ModelChoiceField(
         Participant.objects.all(),
         label=_('participants:merge_form:field:new_participant'),
+        widget=SearchableSelectWidget,
     )
 
     def clean_new_participant(self):


### PR DESCRIPTION
fixes #154

In the old version select widgets were done using some custom js, and I forgot to switch these selects over to the new `SearchableSelectWidget`