### PR TITLE
Feature/simpler cancel

### DIFF
--- a/api/views/participant_views.py
+++ b/api/views/participant_views.py
@@ -288,4 +288,4 @@ class AppointmentsView(rest_mixins.ListModelMixin,
         raise PermissionDenied
 
     def get_queryset(self):
-        return Appointment.objects.filter(participant=self._get_participant())
+        return Appointment.objects.filter(participant=self._get_participant()).order_by('-timeslot__datetime')


### PR DESCRIPTION
Closes #161

see also https://github.com/UiL-OTS-labs/ppn-frontend/pull/22

This PR is about modifying the cancellation link that's included in the appointment confirmation.
The current link leads the participant to a page where they have to enter their mail again, and get yet another link which logs them in.
With the changes in this PR, the original cancellation link already includes a token, so clicking it brings the participant directly to their appointments overview.
